### PR TITLE
Add headers to source files to indicate copyright and license

### DIFF
--- a/semaphore.go
+++ b/semaphore.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License
+// that can be found in the LICENSE.txt file.
+
 package semaphore
 
 import (

--- a/semaphore_test.go
+++ b/semaphore_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License
+// that can be found in the LICENSE.txt file.
+
 package semaphore
 
 import (


### PR DESCRIPTION
This change adds the copyright and license notification headers to the source
code files. There are no functional changes being made here, only comments being
added.

Signed-off-by: Tim Heckman <t@heckman.io>